### PR TITLE
fix(lexer): add token comparison and formatting support

### DIFF
--- a/lib/lexer/dune
+++ b/lib/lexer/dune
@@ -1,4 +1,4 @@
 (library
  (name lexer)
  (public_name chicken.lexer)
- (libraries token))
+ (libraries token fmt))

--- a/lib/lexer/lexer.ml
+++ b/lib/lexer/lexer.ml
@@ -28,8 +28,7 @@ let read_type fn lexer =
   let rec read lex = if fn lex.ch then lex |> read_char |> read else lex in
   let updated_lex = read lexer in
   ( updated_lex,
-    String.sub updated_lex.input position (updated_lex.position - position - 1)
-  )
+    String.sub lexer.input position (updated_lex.position - position) )
 
 let read_identifier = read_type is_letter
 let read_number = read_type is_digit
@@ -39,7 +38,7 @@ let peek_char lexer =
   else String.get lexer.input lexer.read_position
 
 let read_string lexer =
-  let position = lexer.position in
+  let position = lexer.position + 1 in
   let rec read lex =
     if lex.ch = '"' then lex
     else if lex.ch = null_char then lex

--- a/lib/token/dune
+++ b/lib/token/dune
@@ -1,3 +1,4 @@
 (library
  (name token)
- (public_name chicken.token))
+ (public_name chicken.token)
+ (libraries fmt))

--- a/lib/token/token.ml
+++ b/lib/token/token.ml
@@ -69,4 +69,10 @@ let keywords =
     ("return", RETURN);
   ]
 
+let tokens_eq tok_a tok_b =
+  match (tok_a, tok_b) with
+  | IDENT a, IDENT b -> a = b
+  | tok_a, tok_b -> tok_a = tok_b
+
+let pretty_print ppf tok = Fmt.pf ppf "Token %s" (token_to_string tok)
 let lookup_ident str = try List.assoc str keywords with Not_found -> IDENT str

--- a/test/lexer/dune
+++ b/test/lexer/dune
@@ -1,0 +1,5 @@
+
+
+(test
+ (name lexer_test)
+ (libraries lexer alcotest token))

--- a/test/lexer/lexer_test.ml
+++ b/test/lexer/lexer_test.ml
@@ -1,0 +1,145 @@
+(* A module with functions to test *)
+let () =
+  Alcotest.(check (list int))
+    "same lists" [ 1; 2; 3 ]
+    (List.append [ 1 ] [ 2; 3 ])
+
+let token_testable = Alcotest.testable Token.pretty_print Token.tokens_eq
+
+let source_test_string =
+  "let five = 5;\n\n\
+  \  let ten = 10;\n\n\
+  \  let add = fn(x, y) {\n\
+  \    x + y;\n\
+  \  };\n\n\
+  \  let result = add(five, ten);\n\n\
+   \t!-/*5;\n\
+   \t5 < 10 > 5;\n\n\
+   \tif (5 < 10) {\n\
+   \t\treturn true;\n\
+   \t} else {\n\
+   \t\treturn false;\n\
+   \t}\n\n\n\
+   \t10 == 10;\n\
+   \t10 != 9;\n\
+   \t\"string\";\n\
+  \  "
+
+let source_test_expected =
+  [
+    (* // let five = 5 *)
+    Token.LET;
+    Token.IDENT "five";
+    Token.ASSIGN;
+    Token.INT "5";
+    Token.SEMICOLON;
+    (* // let ten = 10 *)
+    Token.LET;
+    Token.IDENT "ten";
+    Token.ASSIGN;
+    Token.INT "10";
+    Token.SEMICOLON;
+    (* // function definition *)
+    Token.LET;
+    Token.IDENT "add";
+    Token.ASSIGN;
+    Token.FUNCTION;
+    Token.LPAREN;
+    Token.IDENT "x";
+    Token.COMMA;
+    Token.IDENT "y";
+    Token.RPAREN;
+    Token.LBRACE;
+    Token.IDENT "x";
+    Token.PLUS;
+    Token.IDENT "y";
+    Token.SEMICOLON;
+    Token.RBRACE;
+    Token.SEMICOLON;
+    (* // result definition *)
+    Token.LET;
+    Token.IDENT "result";
+    Token.ASSIGN;
+    Token.IDENT "add";
+    Token.LPAREN;
+    Token.IDENT "five";
+    Token.COMMA;
+    Token.IDENT "ten";
+    Token.RPAREN;
+    Token.SEMICOLON;
+    (* // junk *)
+    Token.BANG;
+    Token.MINUS;
+    Token.SLASH;
+    Token.ASTERISK;
+    Token.INT "5";
+    Token.SEMICOLON;
+    Token.INT "5";
+    Token.LT;
+    Token.INT "10";
+    Token.GT;
+    Token.INT "5";
+    Token.SEMICOLON;
+    (* // if/else/return *)
+    Token.IF;
+    Token.LPAREN;
+    Token.INT "5";
+    Token.LT;
+    Token.INT "10";
+    Token.RPAREN;
+    Token.LBRACE;
+    Token.RETURN;
+    Token.TRUE;
+    Token.SEMICOLON;
+    Token.RBRACE;
+    Token.ELSE;
+    Token.LBRACE;
+    Token.RETURN;
+    Token.FALSE;
+    Token.SEMICOLON;
+    Token.RBRACE;
+    (* // double character operators *)
+    Token.INT "10";
+    Token.EQ;
+    Token.INT "10";
+    Token.SEMICOLON;
+    Token.INT "10";
+    Token.NOT_EQ;
+    Token.INT "9";
+    Token.SEMICOLON;
+    Token.STRING "string";
+    Token.SEMICOLON;
+    (* sentinel *)
+    Token.EOF;
+  ]
+
+let test_lexer_delimiters () =
+  Alcotest.(check (list token_testable))
+    "same token types"
+    [
+      Token.ASSIGN;
+      Token.PLUS;
+      Token.LPAREN;
+      Token.RPAREN;
+      Token.LBRACE;
+      Token.RBRACE;
+      Token.COMMA;
+      Token.SEMICOLON;
+      Token.EOF;
+    ]
+    (Lexer.generate_tokens "=+(){},;")
+
+let test_lexer_source () =
+  Alcotest.(check (list token_testable))
+    "source code can lex" source_test_expected
+    (Lexer.generate_tokens source_test_string)
+
+(* Run it *)
+let () =
+  Alcotest.run "Lexer"
+    [
+      ( "list-delimiters",
+        [ Alcotest.test_case "first case" `Slow test_lexer_delimiters ] );
+      ( "Lexer.generate_tokens",
+        [ Alcotest.test_case "source code" `Slow test_lexer_source ] );
+    ]


### PR DESCRIPTION
- Add fmt library dependency to lexer and token modules
- Implement token equality comparison for proper test assertions
- Fix string and identifier length calculations in lexer
- Add pretty printing support for token debug output
- Lexer tests