### PR TITLE
feat(ast): implement string representation for AST nodes

### DIFF
--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -1,16 +1,136 @@
-type node = { token_literal : unit -> string; string_ : unit -> string }
-type statement = { node : node }
-type program = { statements : statement list }
-type expression = { node : node }
+type node = { token_literal : unit -> string }
 type identifier = { token : Token.token; value : string }
+type statement = { node : node }
+type block_statement = { token : Token.token; statements : statement list }
 
-type let_statement = {
-  token : Token.token;
-  name : identifier;
-  value : expression;
-}
+type expressions =
+  | Identifier of identifier
+  | IntegerLiteral of { token : Token.token; value : int64 }
+  | StringLiteral of { token : Token.token; value : string }
+  | Boolean of { token : Token.token; value : bool }
+  | PrefixExpression of {
+      token : Token.token;
+      operator : string;
+      right : expressions;
+    }
+  | InfixExpression of {
+      token : Token.token;
+      left : expressions;
+      operator : string;
+      right : expressions;
+    }
+  | IfExpression of {
+      token : Token.token;
+      condition : expressions;
+      consequence : block_statement;
+      alternative : block_statement;
+    }
+  | FunctionLiteral of {
+      token : Token.token;
+      parameters : identifier list;
+      body : block_statement;
+    }
+  | CallExpression of {
+      token : Token.token;
+      func : expressions;
+      arguments : expressions list;
+    }
+  | ArrayLiteral of { token : Token.token; elements : expressions list }
+  | IndexExpression of {
+      token : Token.token;
+      left : expressions;
+      index : expressions;
+    }
+  | HashLiteral of {
+      token : Token.token;
+      pairs : (expressions * expressions) list;
+    }
 
-let statement_to_string (stmt : statement) : string = stmt.node.string_ ()
+and statements =
+  | LetStatement of {
+      token : Token.token;
+      name : identifier;
+      value : expressions;
+    }
+  | ReturnStatement of {
+      token : Token.token;
+      return_value : expressions option;
+    }
+  | ExpressionStatement of {
+      token : Token.token;
+      expression : expressions option;
+    }
+  | BlockStatement of { token : Token.token; statements : statements list }
+
+type program = { statements : statements list }
+
+let rec expression_to_string (expr : expressions) : string =
+  match expr with
+  | Identifier id -> id.value
+  | IntegerLiteral { value; _ } -> Int64.to_string value
+  | StringLiteral { value; _ } -> Printf.sprintf "\"%s\"" value
+  | Boolean { value; _ } -> string_of_bool value
+  | PrefixExpression { operator; right; _ } ->
+      Printf.sprintf "(%s%s)" operator (expression_to_string right)
+  | InfixExpression { left; operator; right; _ } ->
+      Printf.sprintf "(%s %s %s)"
+        (expression_to_string left)
+        operator
+        (expression_to_string right)
+  | IfExpression { condition; consequence; alternative; _ } ->
+      Printf.sprintf "if %s %s else %s"
+        (expression_to_string condition)
+        (block_statement_to_string consequence)
+        (block_statement_to_string alternative)
+  | FunctionLiteral { parameters; body; _ } ->
+      let params =
+        parameters |> List.map (fun p -> p.value) |> String.concat ", "
+      in
+      Printf.sprintf "fn(%s) %s" params (block_statement_to_string body)
+  | CallExpression { func; arguments; _ } ->
+      let args =
+        arguments |> List.map expression_to_string |> String.concat ", "
+      in
+      Printf.sprintf "%s(%s)" (expression_to_string func) args
+  | ArrayLiteral { elements; _ } ->
+      let elems =
+        elements |> List.map expression_to_string |> String.concat ", "
+      in
+      Printf.sprintf "[%s]" elems
+  | IndexExpression { left; index; _ } ->
+      Printf.sprintf "(%s[%s])"
+        (expression_to_string left)
+        (expression_to_string index)
+  | HashLiteral { pairs; _ } ->
+      let pair_strings =
+        pairs
+        |> List.map (fun (k, v) ->
+               Printf.sprintf "%s: %s" (expression_to_string k)
+                 (expression_to_string v))
+        |> String.concat ", "
+      in
+      Printf.sprintf "{%s}" pair_strings
+
+and statement_to_string (stmt : statements) : string =
+  match stmt with
+  | LetStatement { name; value; _ } ->
+      Printf.sprintf "let %s = %s;" name.value (expression_to_string value)
+  | ReturnStatement { return_value; _ } -> (
+      match return_value with
+      | Some expr -> Printf.sprintf "return %s;" (expression_to_string expr)
+      | None -> "return;")
+  | ExpressionStatement { expression; _ } -> (
+      match expression with
+      | Some expr -> expression_to_string expr
+      | None -> "")
+  | BlockStatement { statements; _ } ->
+      statements |> List.map statement_to_string |> String.concat "\n"
+
+and block_statement_to_string (block : block_statement) : string =
+  Printf.sprintf "{ %s }"
+    (block.statements
+    |> List.map (fun s -> s.node.token_literal ())
+    |> String.concat " ")
 
 let program_to_string (program : program) : string =
   program.statements |> List.map statement_to_string |> String.concat "\n"

--- a/test/ast/ast_test.ml
+++ b/test/ast/ast_test.ml
@@ -1,0 +1,76 @@
+let test_let_statement () =
+  let program =
+    {
+      Ast.statements =
+        [
+          LetStatement
+            {
+              token = Token.LET;
+              name = { token = Token.IDENT "myVar"; value = "myVar" };
+              value =
+                Identifier
+                  { token = Token.IDENT "anotherVar"; value = "anotherVar" };
+            };
+        ];
+    }
+  in
+  Alcotest.(check string)
+    "let statement" "let myVar = anotherVar;"
+    (Ast.program_to_string program)
+
+let test_return_statement () =
+  let program =
+    {
+      Ast.statements =
+        [
+          ReturnStatement
+            {
+              token = Token.RETURN;
+              return_value =
+                Some (IntegerLiteral { token = Token.INT "5"; value = 5L });
+            };
+        ];
+    }
+  in
+  Alcotest.(check string)
+    "return statement" "return 5;"
+    (Ast.program_to_string program)
+
+let test_expression_statement () =
+  let program =
+    {
+      Ast.statements =
+        [
+          ExpressionStatement
+            {
+              token = Token.IDENT "x";
+              expression =
+                Some
+                  (InfixExpression
+                     {
+                       token = Token.PLUS;
+                       left =
+                         Identifier { token = Token.IDENT "x"; value = "x" };
+                       operator = "+";
+                       right =
+                         Identifier { token = Token.IDENT "y"; value = "y" };
+                     });
+            };
+        ];
+    }
+  in
+  Alcotest.(check string)
+    "expression statement" "(x + y)"
+    (Ast.program_to_string program)
+
+let () =
+  Alcotest.run "AST"
+    [
+      ( "string representation",
+        [
+          Alcotest.test_case "let statement" `Quick test_let_statement;
+          Alcotest.test_case "return statement" `Quick test_return_statement;
+          Alcotest.test_case "expression statement" `Quick
+            test_expression_statement;
+        ] );
+    ]

--- a/test/ast/dune
+++ b/test/ast/dune
@@ -1,0 +1,5 @@
+
+
+(test
+ (name ast_test)
+ (libraries lexer alcotest token ast))


### PR DESCRIPTION
- Add comprehensive AST node types for expressions and statements
- Implement recursive string conversion for all AST node types
- Add test suite for AST string representation
- Support various expression types including:
  - Literals (Integer, String, Boolean)
  - Prefix and Infix expressions
  - If expressions
  - Function literals
  - Call expressions
  - Array and Hash literals
  - Index expressions