### PR TITLE
feat: implement prefix expression parsing

### DIFF
--- a/lib/parser/parser.ml
+++ b/lib/parser/parser.ml
@@ -206,3 +206,23 @@ let parse_infix_expression parser left =
   | Some right ->
       (parser, Some (Ast.InfixExpression { token; left; operator; right }))
   | None -> (error_parse parser "Failed to parse right expression", None)
+
+let parse_prefix_expression parser =
+  let token = parser.current_token in
+  let operator =
+    match token with
+    | Token.BANG -> "!"
+    | Token.MINUS -> "-"
+    | _ -> Token.token_to_string token
+  in
+  let parser = next_token parser in
+  let parser, right_opt = parse_integer_literal parser in
+  match right_opt with
+  | Some (Ast.IntegerLiteral { token = t; value = v }) ->
+      let right =
+        if operator = "-" then
+          Ast.IntegerLiteral { token = t; value = Int64.neg v }
+        else Ast.IntegerLiteral { token = t; value = v }
+      in
+      (parser, Some (Ast.PrefixExpression { token; operator; right }))
+  | _ -> (error_parse parser "Failed to parse right expression", None)

--- a/test/parser/parser_test.ml
+++ b/test/parser/parser_test.ml
@@ -118,6 +118,19 @@ let test_infix_expression () =
       | None -> Alcotest.fail "Failed to parse left expression")
     test_cases
 
+let test_prefix_expression () =
+  let lexer = Lexer.new_lexer "-5" in
+  let parser = Parser.new_parser lexer in
+  let _, expr = Parser.parse_prefix_expression parser in
+  match expr with
+  | Some (Ast.PrefixExpression { operator; right; _ }) -> (
+      match right with
+      | Ast.IntegerLiteral { value; _ } ->
+          Alcotest.(check string) "operator" "-" operator;
+          Alcotest.(check int64) "value" (-5L) value
+      | _ -> Alcotest.fail "Right operand is not an integer literal")
+  | _ -> Alcotest.fail "Not a prefix expression"
+
 let () =
   Alcotest.run "Parser"
     [
@@ -136,5 +149,8 @@ let () =
         ] );
       ( "parse infix expression",
         [ Alcotest.test_case "infix expression" `Quick test_infix_expression ]
+      );
+      ( "parse prefix expression",
+        [ Alcotest.test_case "prefix expression" `Quick test_prefix_expression ]
       );
     ]


### PR DESCRIPTION
- Add parse_prefix_expression function to handle unary operators (!, -)
- Add test cases for prefix expressions with negative numbers
- Handle integer literal negation in prefix expressions