### PR TITLE
fix: rename COLLON token type to COLON

### DIFF
--- a/lib/lexer/lexer.ml
+++ b/lib/lexer/lexer.ml
@@ -690,7 +690,7 @@ let
 
   | 14 ->
 # 27 "lib/lexer/lexer.mll"
-                  ( new_token COLLON ":" )
+                  ( new_token COLON ":" )
 # 695 "lib/lexer/lexer.ml"
 
   | 15 ->

--- a/lib/lexer/lexer.mll
+++ b/lib/lexer/lexer.mll
@@ -24,7 +24,7 @@ rule token = parse
   | "=="          { new_token EQ "==" }
   | "!="          { new_token NOT_EQ "!=" }
   | ","           { new_token COMMA "," }
-  | ":"           { new_token COLLON ":" }
+  | ":"           { new_token COLON ":" }
   | ";"           { new_token SEMICOLON ";" }
   | "("           { new_token LPAREN "(" }
   | ")"           { new_token RPAREN ")" }

--- a/lib/token/token.ml
+++ b/lib/token/token.ml
@@ -18,7 +18,6 @@ type token_type =
   | NOT_EQ
   (* delimeters *)
   | COMMA
-  | COLLON
   | SEMICOLON
   | LPAREN
   | RPAREN
@@ -26,6 +25,7 @@ type token_type =
   | RBRACE
   | LBRACKET
   | RBRACKET
+  | COLON
   (* keywords *)
   | FUNCTION
   | LET
@@ -58,7 +58,6 @@ let token_to_string token =
   | NOT_EQ -> "NOT_EQ"
   (* delimeters *)
   | COMMA -> "COMMA"
-  | COLLON -> "COLLON"
   | SEMICOLON -> "SEMICOLON"
   | LPAREN -> "LPAREN"
   | RPAREN -> "RPAREN"
@@ -66,6 +65,7 @@ let token_to_string token =
   | RBRACE -> "RBRACE"
   | LBRACKET -> "LBRACKET"
   | RBRACKET -> "RBRACKET"
+  | COLON -> "COLON"
   (* keywords *)
   | FUNCTION -> "FUNCTION"
   | LET -> "LET"

--- a/test/lexer/lexer_test.ml
+++ b/test/lexer/lexer_test.ml
@@ -2,12 +2,28 @@ let token_testable = Alcotest.testable Token.pretty_print Token.tokens_eq
 
 let test_basic_program () =
   let input =
-    "\n\
-    \  let five = 5;\n\
-    \  let ten = 10;\n\
-     let add = fn(x, y) {x + y;};\n\
-     let result = add(five, ten);\n\
-    \  "
+    {|
+    let five = 5;
+    let ten = 10;
+    let add = fn(x, y) {x + y;};
+    let result = add(five, ten);
+
+    !-/*5;
+    5 < 10 > 5;
+
+    if (5 < 10) {
+      return true;
+    } else {
+      return false;
+    }
+
+    10 == 10;
+    10 != 9;
+    "foobar"
+    "foo bar"
+    [1, 2]
+    {"foo": "bar"}
+  |}
   in
   let expected =
     [
@@ -47,6 +63,55 @@ let test_basic_program () =
       (Token.IDENT, "ten");
       (Token.RPAREN, ")");
       (Token.SEMICOLON, ";");
+      (Token.BANG, "!");
+      (Token.MINUS, "-");
+      (Token.SLASH, "/");
+      (Token.ASTERISK, "*");
+      (Token.INT, "5");
+      (Token.SEMICOLON, ";");
+      (Token.INT, "5");
+      (Token.LT, "<");
+      (Token.INT, "10");
+      (Token.GT, ">");
+      (Token.INT, "5");
+      (Token.SEMICOLON, ";");
+      (Token.IF, "if");
+      (Token.LPAREN, "(");
+      (Token.INT, "5");
+      (Token.LT, "<");
+      (Token.INT, "10");
+      (Token.RPAREN, ")");
+      (Token.LBRACE, "{");
+      (Token.RETURN, "return");
+      (Token.TRUE, "true");
+      (Token.SEMICOLON, ";");
+      (Token.RBRACE, "}");
+      (Token.ELSE, "else");
+      (Token.LBRACE, "{");
+      (Token.RETURN, "return");
+      (Token.FALSE, "false");
+      (Token.SEMICOLON, ";");
+      (Token.RBRACE, "}");
+      (Token.INT, "10");
+      (Token.EQ, "==");
+      (Token.INT, "10");
+      (Token.SEMICOLON, ";");
+      (Token.INT, "10");
+      (Token.NOT_EQ, "!=");
+      (Token.INT, "9");
+      (Token.SEMICOLON, ";");
+      (Token.STRING, "foobar");
+      (Token.STRING, "foo bar");
+      (Token.LBRACKET, "[");
+      (Token.INT, "1");
+      (Token.COMMA, ",");
+      (Token.INT, "2");
+      (Token.RBRACKET, "]");
+      (Token.LBRACE, "{");
+      (Token.STRING, "foo");
+      (Token.COLON, ":");
+      (Token.STRING, "bar");
+      (Token.RBRACE, "}");
       (Token.EOF, "");
     ]
   in


### PR DESCRIPTION
- Rename token type COLLON to COLON for better consistency
- Update lexer rules to use the new token name
- Expand test cases to cover string literals, arrays and objects